### PR TITLE
from inspect import iscoroutinefunction not asyncio

### DIFF
--- a/django_valkey/base.py
+++ b/django_valkey/base.py
@@ -3,8 +3,8 @@ import contextlib
 import functools
 import inspect
 import logging
-from asyncio import iscoroutinefunction
 from collections.abc import AsyncGenerator, Callable, Iterator
+from inspect import iscoroutinefunction
 from typing import (
     Any,
     TypeVar,


### PR DESCRIPTION
Fixes: #50
* #50
```diff
- from asyncio import iscoroutinefunction
+ from inspect import iscoroutinefunction
```
https://docs.python.org/3/library/inspect.html#inspect.iscoroutinefunction
https://github.com/search?q=repo%3Adjango-commons%2Fdjango-valkey+iscoroutinefunction&type=code
