### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,10 @@ repos:
     hooks:
       - id: ruff-check
       - id: ruff-format
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell # See pyproject.toml for args
+        additional_dependencies:
+          - tomli

--- a/docs/cluster/basic_configurations.md
+++ b/docs/cluster/basic_configurations.md
@@ -19,7 +19,7 @@ CACHES = {
 
 you need to point to at least one of the cluster nodes in `LOCATION`, or pass a list of multiple nodes
 
-at the moment, only one client is avilable for cluster backend
+at the moment, only one client is available for cluster backend
 
 most of the configurations you see in [basic configuration](../configure/basic_configurations.md) and [advanced configuration](../configure/advanced_configurations.md)
 apply here as well, except the following:
@@ -27,8 +27,8 @@ apply here as well, except the following:
 
 
 ### Memcached exception behavior
-in [Memcahed exception behavior](../configure/basic_configurations.md#memcached-exception-behavior) we discussed how to ignore and log exceptitions,
-sadly, until we find a way around it, this is not accessable with cluster backend
+in [Memcached exception behavior](../configure/basic_configurations.md#memcached-exception-behavior) we discussed how to ignore and log exceptitions,
+sadly, until we find a way around it, this is not accessible with cluster backend
 
 
 ## Multi-key Commands

--- a/docs/commands/raw_access.md
+++ b/docs/commands/raw_access.md
@@ -18,7 +18,7 @@ def get_valkey_connection(alias: str="default", write: bool=True, key=None): ...
 
 `alias` is the name you gave each server in django's `CACHES` setting.
 `write` is used to determine if the operation will write to the cache database, so it should be `True` for `set` and `False` for `get`.
-`key` is only used with the shard client, it'll be explaind below.
+`key` is only used with the shard client, it'll be explained below.
 
 ### get raw access while using shard client
 **note**: this only works as of v0.3.0

--- a/docs/configure/advanced_configurations.md
+++ b/docs/configure/advanced_configurations.md
@@ -255,7 +255,7 @@ the only thing you need to do is install libvalkey:
 pip install django-valkey[libvalkey]
 ```
 
-and valkey-py will take care of te rest
+and valkey-py will take care of the rest
 
 ### Use a custom parser
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,8 @@ DJANGO_SETTINGS_MODULE = "tests.settings.sqlite"
 plugins = ["django_coverage_plugin"]
 parallel = true
 
+[tool.codespell]
+ignore-words-list = "aadd,asend,smove"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401", "F403"]

--- a/tests/tests_cluster/test_backend.py
+++ b/tests/tests_cluster/test_backend.py
@@ -13,7 +13,7 @@ from django_valkey.cluster_cache.cache import ClusterValkeyCache
 
 @pytest.fixture
 def patch_itersize_setting() -> Iterable[None]:
-    # destroy cache to force recreation with overriden settings
+    # destroy cache to force recreation with overridden settings
     del caches["default"]
     with override_settings(DJANGO_VALKEY_SCAN_ITERSIZE=30):
         yield


### PR DESCRIPTION
% `codespell --ignore-words-list=aadd,asend,smove --write-changes`
* https://pypi.org/project/codespell