### PR TITLE
Enhance Ruff CI pipeline with improved lint and format commands

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -4,9 +4,17 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 📝 Run Lint Check
+        uses: astral-sh/ruff-action@v3
         with:
           version: "latest"
-      - run: ruff check
-      - run: ruff format
+          args: "check"
+
+      - name: 🎨 Run Formatting Check
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "latest"
+          args: "format --check"


### PR DESCRIPTION
# PR: Improve Ruff CI Pipeline

This PR fixes **three issues** in the Ruff CI pipeline, improving reliability and correctness.

---

### 1️⃣ Remove redundant Ruff check

* The workflow had an **explicit `ruff check`** running twice.
* Since this is **default behavior** of `astral-sh/ruff-action`, the step was redundant.
* ✅ Prevents duplicate runs and speeds up the pipeline.

---

### 2️⃣ Fix `ruff format` behavior

* `ruff format` is **write-only** by default and didn’t fail in CI if files were unformatted.
* Added `--check` to **exit with a non-zero code** if formatting is needed.
* 🎨 Enforces strict formatting and prevents unformatted code from being merged.

---

### 3️⃣ Avoid `run` after custom action

* Using `run` after a custom action can fail if the action modifies `$PATH`.
* Using the action’s **`args` parameter** ensures all commands run in the same environment.
* ⚠️ Makes the pipeline more reliable and avoids `ruff: command not found` errors.

---

### ✅ Summary

* Removed redundant Ruff checks
* Enforced formatting with `--check`
* Improved CI reliability by avoiding unsafe `run` steps