### PR TITLE
DRAFT: Add free threaded Python 3.14t to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           - '3.12'
           - '3.13'
           - '3.14'
+          - '3.14t'
         django-version:
           - 'django==4.2'
           - 'django==5.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ libvalkey = [
     "libvalkey>=4.0.1",
 ]
 lz4 = [
-    "lz4>=4.3.3",
+    "lz4>=4.4.5",
 ]
 pyzstd = [
     "pyzstd>=0.16.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ libvalkey = [
     "libvalkey>=4.0.1",
 ]
 lz4 = [
-    "lz4>=4.4.5",
+    "lz4>=4.3.3",
 ]
 pyzstd = [
     "pyzstd>=0.16.2",


### PR DESCRIPTION
Continues the work started in:
* #49 

Blocked by:
* ~valkey-io/libvalkey-py#35~
* A `libvalkey-py` release > v4.0.1 https://github.com/valkey-io/libvalkey-py/releases

Pytest warning:
> =============================== warnings summary ===============================
<frozen importlib._bootstrap>:491
  <frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'libvalkey.libvalkey', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.

Blocked by:
* google/brotli#1241
* valkey-io/libvalkey-py#42