### PR TITLE
Drop support for Django 5.0 & 5.1 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
           - '3.14'
         django-version:
           - 'django==4.2'
-          - 'django==5.0'
-          - 'django==5.1'
           - 'django==5.2'
           - 'django==6.0'
 

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Requirements
 
 - `Python`_ 3.10+
 - `Django`_ 4.2.20+
+    - `Django~=5.0` and `Django~=5.1` are not supported, because they are end of life: https://endoflife.date/django
 - `valkey-py`_ 6.0.2+
 - `Valkey server`_ 7.2.6+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,12 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0"
 ]
 
 dependencies = [
-    "django>=4.2",
+    "django>=4.2,!=5.0.*,!=5.1.*",
     "valkey>=6.0.2",
 ]
 


### PR DESCRIPTION
https://endoflife.date/django