### PR TITLE
fix: coroutine `close_async_caches` was never awaited

### DIFF
--- a/django_valkey/base.py
+++ b/django_valkey/base.py
@@ -593,6 +593,7 @@ class AsyncBackendCommands:
 from django.core import signals  # noqa: E402
 from django.core.cache import caches, close_caches  # noqa: E402
 
+
 def close_sync_caches(**kwargs):
     """
     Synchronous cache closer for WSGI environments.
@@ -613,11 +614,11 @@ async def close_async_and_sync_caches(**kwargs):
         else:
             conn.close()
 
+
 has_async_cache = any(
-    getattr(conn, "is_async", False)
-    for conn in caches.all(initialized_only=True)
+    getattr(conn, "is_async", False) for conn in caches.all(initialized_only=True)
 )
-    
+
 if has_async_cache:
     signals.request_finished.connect(close_async_and_sync_caches)
 else:

--- a/django_valkey/base.py
+++ b/django_valkey/base.py
@@ -593,14 +593,34 @@ class AsyncBackendCommands:
 from django.core import signals  # noqa: E402
 from django.core.cache import caches, close_caches  # noqa: E402
 
+def close_sync_caches(**kwargs):
+    """
+    Synchronous cache closer for WSGI environments.
+    Only closes synchronous cache backends.
+    """
+    for conn in caches.all(initialized_only=True):
+        conn.close()
 
-async def close_async_caches(**kwargs):
+
+async def close_async_and_sync_caches(**kwargs):
+    """
+    Asynchronous cache closer for ASGI environments.
+    Handles both sync and async cache backends.
+    """
     for conn in caches.all(initialized_only=True):
         if getattr(conn, "is_async", False):
             await conn.aclose()
         else:
             conn.close()
 
+has_async_cache = any(
+    getattr(conn, "is_async", False)
+    for conn in caches.all(initialized_only=True)
+)
+    
+if has_async_cache:
+    signals.request_finished.connect(close_async_and_sync_caches)
+else:
+    signals.request_finished.connect(close_sync_caches)
 
-signals.request_finished.connect(close_async_caches)
 signals.request_finished.disconnect(close_caches)


### PR DESCRIPTION
**Problem:**
When using WSGI servers with django_valkey you get the following error: 
`/usr/local/lib/python3.10/site-packages/django/http/response.py:335: RuntimeWarning: coroutine 'close_async_caches' was never awaited`

**Reason:**
The current implementation connects an async connection closer to `request_finished`, which creates un-awaited coroutines in WSGI environments where no event loop exists. Although the implementation checks whether the Valkey object `is_async`, the function itself is defined as `await def` and thus throws an error. 

Furthermore, even if users set `CLOSE_CONNECTION = False`, this does not prevent django from running the buggy `close_async_caches` function.

**Solution:**
Create separate sync and async handlers, and only connect the async version when async backends are detected.