### PR TITLE
Fix typo in copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (v) 2024 Amirreza Sohrabi far
+Copyright (c) 2024 Amirreza Sohrabi far
 Copyright (c) 2011-2016 Andrey Antukh <niwi@niwi.nz>
 Copyright (c) 2011 Sean Bleier
 


### PR DESCRIPTION
## Summary

This PR fixes a typo in the license header.

The copyright notice currently uses "(v)" instead of the standard "(c)" notation. This change replaces "(v)" with "(c)" for consistency with the other copyright notices in the file.

## Changes

* Replace `Copyright (v) 2024 Amirreza Sohrabi far`
* With `Copyright (c) 2024 Amirreza Sohrabi far`

## Impact

Documentation/license text only. No functional changes.
