### PR TITLE
Correct the name of the global var for logging ignored exceptions

### DIFF
--- a/docs/configure/basic_configurations.md
+++ b/docs/configure/basic_configurations.md
@@ -80,7 +80,7 @@ DJANGO_VALKEY_IGNORE_EXCEPTIONS = True
 
 ### Log exceptions when ignored
 
-when ignoring exceptions with `IGNORE_EXCEPTIONS` or `DJANGO_VALKEY_IGNORE_EXCEPTION`, you may optionally log exceptions by setting the global variable `DJANGO_VALKEY_LOG_EXCEPTION` in your settings:
+when ignoring exceptions with `IGNORE_EXCEPTIONS` or `DJANGO_VALKEY_IGNORE_EXCEPTION`, you may optionally log exceptions by setting the global variable `DJANGO_VALKEY_LOG_IGNORED_EXCEPTION` in your settings:
 
 ```python
 DJANGO_VALKEY_LOG_IGNORED_EXCEPTION = True


### PR DESCRIPTION
`DJANGO_VALKEY_LOG_EXCEPTION` only shows up in this example documentation below and not in the codebase.
The actual code checks `DJANGO_VALKEY_LOG_IGNORED_EXCEPTION`
https://github.com/django-commons/django-valkey/blob/2abe247db5088e153f8259b8184f78ea3524e855/django_valkey/base.py#L190

